### PR TITLE
Enabled cloudfront s3 accesslog, enabled origin shield

### DIFF
--- a/access-log.tf
+++ b/access-log.tf
@@ -1,0 +1,46 @@
+resource "random_pet" "access_log" {
+  keepers = {
+    account = local.region_name
+    region  = local.account_id
+    name    = local.name_prefix
+  }
+}
+
+resource "aws_s3_bucket" "access_log" {
+  bucket = "${local.name_prefix}access-log-${random_pet.access_log.id}"
+  tags   = local.default_tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "access_log" {
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "access_log" {
+  bucket = aws_s3_bucket.access_log.id
+
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "access_log" {
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    id     = "access-log-retention"
+    status = "Enabled"
+
+    filter {
+      prefix = "cloudfront/"
+    }
+
+    expiration {
+      days = var.config.log_retention
+    }
+  }
+}

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -24,6 +24,15 @@ resource "aws_cloudfront_distribution" "this" {
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
     }
+
+    dynamic "origin_shield" {
+      for_each = var.config.origin_shield_region != null ? [1] : []
+
+      content {
+        enabled              = true
+        origin_shield_region = var.config.origin_shield_region
+      }
+    }
   }
 
   default_cache_behavior {
@@ -34,11 +43,11 @@ resource "aws_cloudfront_distribution" "this" {
     cache_policy_id        = data.aws_cloudfront_cache_policy.this.id
   }
 
-  # logging_config {
-  #   include_cookies = false
-  #   bucket          = "mylogs.s3.amazonaws.com"
-  #   prefix          = "myprefix"
-  # }
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.access_log.bucket_domain_name
+    prefix          = "cloudfront/"
+  }
 
   restrictions {
     geo_restriction {

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,16 @@
 variable "config" {
   description = ""
   type = object({
-    domain_name         = string
-    domain_alias        = optional(set(string), [])
-    index_document      = optional(string, "index.html")
-    error_document      = optional(string, "index.html")
-    allowed_ip_cidrs    = optional(set(string), [])
-    cache_policy        = optional(string, "CachingOptimized")
-    acm_certificate_arn = optional(string)
-    disable_cloudfront  = optional(bool, false)
-    kms_arn             = optional(string)
+    domain_name          = string
+    domain_alias         = optional(set(string), [])
+    index_document       = optional(string, "index.html")
+    error_document       = optional(string, "index.html")
+    allowed_ip_cidrs     = optional(set(string), [])
+    cache_policy         = optional(string, "CachingOptimized")
+    origin_shield_region = optional(string, "eu-central-1")
+    acm_certificate_arn  = optional(string)
+    disable_cloudfront   = optional(bool, false)
+    kms_arn              = optional(string)
+    log_retention        = optional(number, 35)
   })
 }


### PR DESCRIPTION
- Enabled cloudfront s3 accesslog with default retention period of 35 days
- Enable origin shield (regional caching for faster response times)