### PR TITLE
feat: upgraded tf to v.1.9

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.6.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 4.0"
       configuration_aliases = [
         aws.use1
       ]

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
       configuration_aliases = [
         aws.use1
       ]

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9.0"
+  required_version = ">= 1.6.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Upgraded terraform to `">= 1.6.0"` constraint following [tf version constraints best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints). The upgrade has been done following  the 1.7 to 1.9 upgrade guides on [hashicorp.com](https://developer.hashicorp.com/terraform/language/v1.7.x/upgrade-guides).

Upgraded aws provider to `">= 4.0"` constraint following [upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade).

